### PR TITLE
Install with prefix work around

### DIFF
--- a/build-emacs.sh
+++ b/build-emacs.sh
@@ -31,6 +31,10 @@ cd emacs-"$version"
     --with-x-toolkit=lucid
 
 make
-sudo make install prefix=/usr/local/stow/emacs-"$version"
+sudo make install \
+    install-arch-dep \
+    install-arch-indep \
+    prefix=/usr/local/stow/emacs-"$version"
+
 cd /usr/local/stow
 sudo stow emacs-"$version"


### PR DESCRIPTION
- Calling `make install prefix=/path/to/prefix`
  cause some files to be re-compiled.
- This commit add the work around as suggesting in
  http://www.gnu.org/software/stow/manual/stow.html#GNU-Emacs
